### PR TITLE
Add Reddit Query Service and Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/RedditController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/RedditController.java
@@ -1,10 +1,41 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import edu.ucsb.cs156.spring.backenddemo.services.RedditQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+@Api(description="Info from Reddit.com")
+@Slf4j
 @RestController
+@RequestMapping("/api/reddit/get")
 public class RedditController {
-    
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    RedditQueryService redditQueryService;
+
+    @ApiOperation(value="Get posts from a subreddit of Reddit.com")
+    @GetMapping("/get")
+    public ResponseEntity<String> getCountryCodes(
+        @ApiParam("subreddit, e.g. UCSantaBarbara") @RequestParam String subreddit
+    ) throws JsonProcessingException {
+        log.info("getSubreddit: subreddit={}", subreddit);
+        String result = redditQueryService.getJSON(subreddit);
+        return ResponseEntity.ok().body(result);
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/RedditQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/RedditQueryService.java
@@ -2,13 +2,22 @@ package edu.ucsb.cs156.spring.backenddemo.services;
 
 import org.springframework.web.client.RestTemplate;
 
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
-
+@Slf4j
 @Service
 public class RedditQueryService {
 
@@ -18,10 +27,22 @@ public class RedditQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://www.reddit.com/r/{subreddit}.json";
 
     public String getJSON(String subreddit) throws HttpClientErrorException {
-        return "";
+        log.info("subreddit={}", subreddit);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("User-Agent","spring-boot:cs156-team01:f22 (by /u/Extra-Editor4414)");
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of("subreddit", subreddit);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 
    

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/RedditControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/RedditControllerTest.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.RedditQueryService;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(value = RedditController.class)
+public class RedditControllerTest {
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  RedditQueryService mockRedditQueryService;
+
+
+  @Test
+  public void test_getSubreddit() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String subreddit = "UCSantaBarbara";
+    when(mockRedditQueryService.getJSON(eq(subreddit))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/reddit/get/get?subreddit=%s", subreddit);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/RedditQueryServiceTest.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/RedditQueryServiceTest.java
@@ -1,0 +1,40 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(RedditQueryService.class)
+public class RedditQueryServiceTest {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private RedditQueryService redditQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String subreddit = "UCSantaBarbara";
+        String expectedURL = RedditQueryService.ENDPOINT.replace("{subreddit}", subreddit);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = redditQueryService.getJSON(subreddit);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/reddit/get` that can be used to get the posts of a subreddit from reddit.com

Closes #9 
Closes #10