### PR TITLE
Add `TidesController` and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+
+# Path to this Makefile.
+self := $(abspath $(lastword ${MAKEFILE_LIST}))
+
+.PHONY: run
+run:	# Run the application.
+	mvn spring-boot:run
+
+.PHONY: help
+help:	# Generate a list of targets.
+	@cat ${self} | grep '^[[:alnum:]_-]*:' | \
+		sed 's/^\([[:alnum:]_-]*\):[[:space:][:alnum:]_-]*/\1\t\t/' | sort

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ self := $(abspath $(lastword ${MAKEFILE_LIST}))
 run:	# Run the application.
 	mvn spring-boot:run
 
+.PHONY: test
+test:	# Test the application.
+	mvn test
+
+.PHONY: coverage
+coverage:	# Run code coverage.
+	mvn test jacoco:report
+
 .PHONY: help
 help:	# Generate a list of targets.
 	@cat ${self} | grep '^[[:alnum:]_-]*:' | \

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
@@ -1,9 +1,39 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
+@Api("Historical tide data from NOAA")
+@Slf4j
 @RestController
+@RequestMapping("/api/tides")
 public class TidesController {
+    ObjectMapper mapper = new ObjectMapper();
 
+    @Autowired
+    TidesQueryService tidesQueryService;
+
+    @ApiOperation("Get historical tide data from NOAA.")
+    @GetMapping("/get")
+    public ResponseEntity<String> getTides(
+            @ApiParam("first date in range to query in yyyyMMdd format") @RequestParam String beginDate,
+            @ApiParam("final date in range to query in yyyyMMdd format") @RequestParam String endDate,
+            @ApiParam("NOAA station code") @RequestParam String station
+    ) throws JsonProcessingException {
+        log.info("getTides: beginDate={}, endDate={}, station={}", beginDate, endDate, station);
+        String result = tidesQueryService.getJSON(beginDate, endDate, station);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -2,8 +2,7 @@ package edu.ucsb.cs156.spring.backenddemo.services;
 
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
@@ -13,11 +12,12 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+import java.util.List;
+import java.util.Map;
 
+@Slf4j
 @Service
 public class TidesQueryService {
-
-
     private final RestTemplate restTemplate;
 
     public TidesQueryService(RestTemplateBuilder restTemplateBuilder) {
@@ -25,9 +25,23 @@ public class TidesQueryService {
     }
 
     // Documentation for endpoint is at: https://api.tidesandcurrents.noaa.gov/api/prod/
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
-        return "";
+        log.info("beginDate={}, endDate={}, station={}", beginDate, endDate, station);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of(
+                "beginDate", beginDate,
+                "endDate", endDate,
+                "station", station
+        );
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables);
+        return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(value = TidesController.class)
+public class TidesControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  TidesQueryService mockTideQueryService;
+
+
+  @Test
+  public void test_getTides() throws Exception {
+    String beginDate = "20220101";
+    String endDate = "20220104";
+    String station = "9411340";
+    String mockResult = "this is another mock result";
+
+    when(mockTideQueryService.getJSON(eq(beginDate), eq(endDate), eq(station)))
+            .thenReturn(mockResult);
+
+    String url = String.format("/api/tides/get?beginDate=%s&endDate=%s&station=%s", beginDate, endDate, station);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(responseString, mockResult);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import javax.print.attribute.standard.Media;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RestClientTest(TidesQueryService.class)
+public class TidesQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private TidesQueryService earthquakeQueryService;
+
+    @Test
+    public void test_getJSON() {
+        String beginDate = "20220101";
+        String endDate = "20220104";
+        String station = "9411340";
+
+        String expectedUrl = TidesQueryService.ENDPOINT.replace("{beginDate}", beginDate)
+                .replace("{endDate}", endDate)
+                .replace("{station}", station);
+
+        String mockResult = "this is a mock result";
+
+        this.mockRestServiceServer.expect(requestTo(expectedUrl))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(mockResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = earthquakeQueryService.getJSON(beginDate, endDate, station);
+        assertEquals(actualResult, mockResult);
+    }
+}


### PR DESCRIPTION
Add controller for tide query API `/api/tides/get` for querying historical tide forecasts, as well as associated tests. Closes #7.