### PR TITLE
Add `TidesQueryService` and associated tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+
+# Path to this Makefile.
+self := $(abspath $(lastword ${MAKEFILE_LIST}))
+
+.PHONY: run
+run:	# Run the application.
+	mvn spring-boot:run
+
+.PHONY: help
+help:	# Generate a list of targets.
+	@cat ${self} | grep '^[[:alnum:]_-]*:' | \
+		sed 's/^\([[:alnum:]_-]*\):[[:space:][:alnum:]_-]*/\1\t\t/' | sort

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ self := $(abspath $(lastword ${MAKEFILE_LIST}))
 run:	# Run the application.
 	mvn spring-boot:run
 
+.PHONY: test
+test:	# Test the application.
+	mvn test
+
+.PHONY: coverage
+coverage:	# Run code coverage.
+	mvn test jacoco:report
+
 .PHONY: help
 help:	# Generate a list of targets.
 	@cat ${self} | grep '^[[:alnum:]_-]*:' | \

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -2,8 +2,7 @@ package edu.ucsb.cs156.spring.backenddemo.services;
 
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
@@ -13,11 +12,12 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+import java.util.List;
+import java.util.Map;
 
+@Slf4j
 @Service
 public class TidesQueryService {
-
-
     private final RestTemplate restTemplate;
 
     public TidesQueryService(RestTemplateBuilder restTemplateBuilder) {
@@ -25,9 +25,23 @@ public class TidesQueryService {
     }
 
     // Documentation for endpoint is at: https://api.tidesandcurrents.noaa.gov/api/prod/
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
-        return "";
+        log.info("beginDate={}, endDate={}, station={}", beginDate, endDate, station);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of(
+                "beginDate", beginDate,
+                "endDate", endDate,
+                "station", station
+        );
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables);
+        return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import javax.print.attribute.standard.Media;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RestClientTest(TidesQueryService.class)
+public class TidesQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private TidesQueryService earthquakeQueryService;
+
+    @Test
+    public void test_getJSON() {
+        String beginDate = "20220101";
+        String endDate = "20220104";
+        String station = "9411340";
+
+        String expectedUrl = TidesQueryService.ENDPOINT.replace("{beginDate}", beginDate)
+                .replace("{endDate}", endDate)
+                .replace("{station}", station);
+
+        String mockResult = "this is a mock result";
+
+        this.mockRestServiceServer.expect(requestTo(expectedUrl))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(mockResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = earthquakeQueryService.getJSON(beginDate, endDate, station);
+        assertEquals(actualResult, mockResult);
+    }
+}


### PR DESCRIPTION
Add query service for tide query API `/api/tides/get` for querying historical tide forecasts, as well as associated tests. Blocks #18. Closes #8.